### PR TITLE
Generalise Dependabot reviewers

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,24 +7,21 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     reviewers:
-      - "Sassiest01"
-      - "willsawyerrrr"
+      - "SituDevelopment/employees"
     directory: "/"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "npm"
     reviewers:
-      - "Sassiest01"
-      - "willsawyerrrr"
+      - "SituDevelopment/employees"
     directory: "/"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "github-actions"
     reviewers:
-      - "Sassiest01"
-      - "willsawyerrrr"
+      - "SituDevelopment/employees"
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Prevented need to add/remove reviewer usernames by utilising Github teams