### PR TITLE
Correctly Configure Status Checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest an idea for this project
-title: 'Feature Request: '
+title: "Feature Request: "
 labels: enhancement
 
 body:

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -18,7 +18,6 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          ls -la
           ./find-by-extension ".py"
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          curl https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension?token=${{ secrets.GITHUB_TOKEN }} -o find-by-extension
           chmod +x find-by-extension
       - id: find-python
         run: |

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          echo ${{ secrets.GITHUB_TOKEN }}}
+          echo ${{ secrets.GITHUB_TOKEN }}
           curl https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension?token=${{ secrets.GITHUB_TOKEN }} -o find-by-extension
           chmod +x find-by-extension
       - id: find-python

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -16,19 +16,16 @@ jobs:
       - run: |
           curl -H "Authorization: token ${{ secrets.DOWNLOAD_FIND_BY_EXTENSION }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
           chmod +x find-by-extension
-          cat find-by-extension
       - id: find-python
         run: |
           if [ -n $(./find-by-extension ".py") ]; then
               echo "result=true" >> "$GITHUB_OUTPUT"
-              echo "result=true"
           else
               echo "result=false" >> "$GITHUB_OUTPUT"
-              echo "result=false"
           fi
       - id: find-web
         run: |
-          .if [ -n $(/find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]; then
+          if [ -n $(./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
             echo "result=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -13,11 +13,9 @@ jobs:
       web: ${{ steps.find-web.outputs.result }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          repository: "SituDevelopment/automation"
-          sparse-checkout: "find-by-extension"
-          token: ${{ github.token }}
+      - run: |
+          curl -H "Authorization: token ${{ github.token }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          chmod +x find-by-extension
       - id: find-python
         run: |
           find-by-extension ".py" > /dev/null

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -20,9 +20,11 @@ jobs:
       - id: find-python
         run: |
           if [ -n $(./find-by-extension ".py") ]; then
-            echo "result=true" >> "$GITHUB_OUTPUT"
+              echo "result=true" >> "$GITHUB_OUTPUT"
+              echo "result=true"
           else
-            echo "result=false" >> "$GITHUB_OUTPUT"
+              echo "result=false" >> "$GITHUB_OUTPUT"
+              echo "result=false"
           fi
       - id: find-web
         run: |

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -19,16 +19,14 @@ jobs:
           cat find-by-extension
       - id: find-python
         run: |
-          ./find-by-extension ".py"
-          if [ $? -eq 0 ]; then
+          if [ -n $(./find-by-extension ".py") ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
             echo "result=false" >> "$GITHUB_OUTPUT"
           fi
       - id: find-web
         run: |
-          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml"
-          if [ $? -eq 0 ]; then
+          .if [ -n $(/find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
             echo "result=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -6,13 +6,28 @@ on:
       - main
 
 jobs:
+  find:
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.find-python.outputs.result }}
+      web: ${{ steps.find-web.outputs.result }}
+    steps:
+      - id: find-python
+        run: echo "result=${{ hashFiles('**.py') }}" >> "$GITHUB_OUTPUT"
+      - id: find-web
+        run: echo "result=${{ hashFiles('**.cjs, **.css, **.html, **.html.jinja, **.js, **.json, **.jsx, **.md, **.scss, **.ts, **.tsx, **.yaml, **.yml') }}" >> "$GITHUB_OUTPUT"
+
   black:
+    if: needs.find.outputs.python
+    needs: find
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
 
   isort:
+    if: needs.find.outputs.python
+    needs: find
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +37,8 @@ jobs:
           requirements-files: "requirements.txt"
 
   prettier:
+    if: needs.find.outputs.web
+    needs: find
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +51,8 @@ jobs:
         run: prettier --check .
 
   pylint:
+    if: needs.find.outputs.python
+    needs: find
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -18,14 +18,14 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          if [ -n $(./find-by-extension ".py") ]; then
+          if [[ -n $(./find-by-extension ".py") ]]; then
               echo "result=true" >> "$GITHUB_OUTPUT"
           else
               echo "result=false" >> "$GITHUB_OUTPUT"
           fi
       - id: find-web
         run: |
-          if [ -n $(./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]; then
+          if [[ -n $(./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
             echo "result=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
+          echo ${{ secrets.GITHUB_TOKEN }}}
           curl https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension?token=${{ secrets.GITHUB_TOKEN }} -o find-by-extension
           chmod +x find-by-extension
       - id: find-python

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -18,6 +18,7 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
+          ls
           ./find-by-extension ".py"
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl -H "Authorization: token ${{ secrets.DOWNLOAD_FIND_BY_EXTENSION }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          curl -H "Authorization: token ${{ secrets.DOWNLOAD_FIND_BY_EXTENSION }}" https://raw.githubusercontent.com/SituDevelopment/automation/added-debugging-prints/find-by-extension -o find-by-extension
           chmod +x find-by-extension
           cat find-by-extension
       - id: find-python

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl -H "Authorization: token ${{ secrets.DOWNLOAD_FIND_BY_EXTENSION }}" https://raw.githubusercontent.com/SituDevelopment/automation/added-debugging-prints/find-by-extension -o find-by-extension
+          curl -H "Authorization: token ${{ secrets.DOWNLOAD_FIND_BY_EXTENSION }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
           chmod +x find-by-extension
           cat find-by-extension
       - id: find-python

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -13,13 +13,28 @@ jobs:
       web: ${{ steps.find-web.outputs.result }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: "SituDevelopment/automation"
       - id: find-python
-        run: echo "result=${{ hashFiles('**.py') }}" >> "$GITHUB_OUTPUT"
+        run: |
+          find-by-extension ".py" > /dev/null
+          if [ $? -eq 0 ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+          fi
       - id: find-web
-        run: echo "result=${{ hashFiles('**.cjs, **.css, **.html, **.html.jinja, **.js, **.json, **.jsx, **.md, **.scss, **.ts, **.tsx, **.yaml, **.yml') }}" >> "$GITHUB_OUTPUT"
+        run: |
+          find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
+          if [ $? -eq 0 ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+          fi
 
   black:
-    if: needs.find.outputs.python
+    if: fromJSON(needs.find.outputs.python)
     needs: find
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +42,7 @@ jobs:
       - uses: psf/black@stable
 
   isort:
-    if: needs.find.outputs.python
+    if: fromJSON(needs.find.outputs.python)
     needs: find
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +53,7 @@ jobs:
           requirements-files: "requirements.txt"
 
   prettier:
-    if: needs.find.outputs.web
+    if: fromJSON(needs.find.outputs.web)
     needs: find
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +67,7 @@ jobs:
         run: prettier --check .
 
   pylint:
-    if: needs.find.outputs.python
+    if: fromJSON(needs.find.outputs.python)
     needs: find
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -18,7 +18,7 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          ls
+          ls -la
           ./find-by-extension ".py"
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -12,6 +12,7 @@ jobs:
       python: ${{ steps.find-python.outputs.result }}
       web: ${{ steps.find-web.outputs.result }}
     steps:
+      - uses: actions/checkout@v4
       - id: find-python
         run: echo "result=${{ hashFiles('**.py') }}" >> "$GITHUB_OUTPUT"
       - id: find-web

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -18,7 +18,7 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          ./find-by-extension ".py" > /dev/null
+          ./find-by-extension ".py"
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
@@ -26,7 +26,7 @@ jobs:
           fi
       - id: find-web
         run: |
-          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
+          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml"
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: "SituDevelopment/automation"
+          sparse-checkout: "find-by-extension"
+          token: ${{ github.token }}
       - id: find-python
         run: |
           find-by-extension ".py" > /dev/null

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -18,7 +18,7 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          find-by-extension ".py" > /dev/null
+          ./find-by-extension ".py" > /dev/null
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
@@ -26,7 +26,7 @@ jobs:
           fi
       - id: find-web
         run: |
-          find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
+          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl -H "Authorization: token ${{ github.token }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
           chmod +x find-by-extension
       - id: find-python
         run: |

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -1,0 +1,48 @@
+name: Check Code Style
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: psf/black@stable
+
+  isort:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: isort/isort-action@v1
+        with:
+          configuration: "--check-only --diff --profile black"
+          requirements-files: "requirements.txt"
+
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - name: Installing Prettier
+        run: npm install --global prettier
+      - name: Running Prettier
+        run: prettier --check .
+
+  pylint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Installing Pylint
+        run: |
+          python -m pip install --upgrade pip
+          pip install pylint
+      - name: Running Pylint
+        run: pylint .

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -16,6 +16,7 @@ jobs:
       - run: |
           curl -H "Authorization: token ${{ secrets.DOWNLOAD_FIND_BY_EXTENSION }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
           chmod +x find-by-extension
+          cat find-by-extension
       - id: find-python
         run: |
           ./find-by-extension ".py"

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "18"
       - name: Installing Prettier
         run: npm install --global prettier
       - name: Running Prettier

--- a/.github/workflows/check-code-style.yaml
+++ b/.github/workflows/check-code-style.yaml
@@ -14,8 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          echo ${{ secrets.GITHUB_TOKEN }}
-          curl https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension?token=${{ secrets.GITHUB_TOKEN }} -o find-by-extension
+          curl -H "Authorization: token ${{ secrets.DOWNLOAD_FIND_BY_EXTENSION }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
           chmod +x find-by-extension
       - id: find-python
         run: |

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -1,0 +1,35 @@
+name: Check Dependencies
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: |
+          if [[ -f requirements.txt ]]; then
+              pip install -r requirements.txt --platform manylinux2014_x86_64 --only-binary=":all:" --target=dependencies
+          else
+              echo "requirements.txt not found"
+          fi
+
+  npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - run: |
+          if [[ -f package.json && -f package-lock.json ]]; then
+              npm install
+          else
+              echo "package.json and/or package-lock.json not found"
+          fi

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          curl https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension?token=${{ secrets.GITHUB_TOKEN }} -o find-by-extension
           chmod +x find-by-extension
       - id: find-python
         run: |

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -13,11 +13,9 @@ jobs:
       web: ${{ steps.find-web.outputs.result }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          repository: "SituDevelopment/automation"
-          sparse-checkout: "find-by-extension"
-          token: ${{ github.token }}
+      - run: |
+          curl -H "Authorization: token ${{ github.token }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          chmod +x find-by-extension
       - id: find-python
         run: |
           find-by-extension ".py" > /dev/null

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -6,7 +6,20 @@ on:
       - main
 
 jobs:
+  find:
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.find-python.outputs.result }}
+      web: ${{ steps.find-web.outputs.result }}
+    steps:
+      - id: find-python
+        run: echo "result=${{ hashFiles('**.py') }}" >> "$GITHUB_OUTPUT"
+      - id: find-web
+        run: echo "result=${{ hashFiles('**.cjs, **.css, **.html, **.html.jinja, **.js, **.json, **.jsx, **.md, **.scss, **.ts, **.tsx, **.yaml, **.yml') }}" >> "$GITHUB_OUTPUT"
+
   pip:
+    if: needs.find.outputs.python
+    needs: find
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,6 +34,8 @@ jobs:
           fi
 
   npm:
+    if: needs.find.outputs.web
+    needs: find
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension?token=${{ secrets.GITHUB_TOKEN }} -o find-by-extension
+          curl -H "Authorization: token ${{ secrets.DOWNLOAD_FIND_BY_EXTENSION }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
           chmod +x find-by-extension
       - id: find-python
         run: |

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -18,14 +18,14 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          if [ -n $(./find-by-extension ".py") ]; then
+          if [[ -n $(./find-by-extension ".py") ]]; then
               echo "result=true" >> "$GITHUB_OUTPUT"
           else
               echo "result=false" >> "$GITHUB_OUTPUT"
           fi
       - id: find-web
         run: |
-          if [ -n $(./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]; then
+          if [[ -n $(./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
             echo "result=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -13,13 +13,28 @@ jobs:
       web: ${{ steps.find-web.outputs.result }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: "SituDevelopment/automation"
       - id: find-python
-        run: echo "result=${{ hashFiles('**.py') }}" >> "$GITHUB_OUTPUT"
+        run: |
+          find-by-extension ".py" > /dev/null
+          if [ $? -eq 0 ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+          fi
       - id: find-web
-        run: echo "result=${{ hashFiles('**.cjs, **.css, **.html, **.html.jinja, **.js, **.json, **.jsx, **.md, **.scss, **.ts, **.tsx, **.yaml, **.yml') }}" >> "$GITHUB_OUTPUT"
+        run: |
+          find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
+          if [ $? -eq 0 ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+          fi
 
   pip:
-    if: needs.find.outputs.python
+    if: fromJSON(needs.find.outputs.python)
     needs: find
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +50,7 @@ jobs:
           fi
 
   npm:
-    if: needs.find.outputs.web
+    if: fromJSON(needs.find.outputs.web)
     needs: find
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -18,16 +18,14 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          ./find-by-extension ".py"
-          if [ $? -eq 0 ]; then
-            echo "result=true" >> "$GITHUB_OUTPUT"
+          if [ -n $(./find-by-extension ".py") ]; then
+              echo "result=true" >> "$GITHUB_OUTPUT"
           else
-            echo "result=false" >> "$GITHUB_OUTPUT"
+              echo "result=false" >> "$GITHUB_OUTPUT"
           fi
       - id: find-web
         run: |
-          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml"
-          if [ $? -eq 0 ]; then
+          if [ -n $(./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
             echo "result=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -12,6 +12,7 @@ jobs:
       python: ${{ steps.find-python.outputs.result }}
       web: ${{ steps.find-web.outputs.result }}
     steps:
+      - uses: actions/checkout@v4
       - id: find-python
         run: echo "result=${{ hashFiles('**.py') }}" >> "$GITHUB_OUTPUT"
       - id: find-web

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -18,7 +18,7 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          ./find-by-extension ".py" > /dev/null
+          ./find-by-extension ".py"
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
@@ -26,7 +26,7 @@ jobs:
           fi
       - id: find-web
         run: |
-          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
+          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml"
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: "SituDevelopment/automation"
+          sparse-checkout: "find-by-extension"
+          token: ${{ github.token }}
       - id: find-python
         run: |
           find-by-extension ".py" > /dev/null

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -18,7 +18,7 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          find-by-extension ".py" > /dev/null
+          ./find-by-extension ".py" > /dev/null
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
@@ -26,7 +26,7 @@ jobs:
           fi
       - id: find-web
         run: |
-          find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
+          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl -H "Authorization: token ${{ github.token }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
           chmod +x find-by-extension
       - id: find-python
         run: |

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,13 @@
+name: Dependabot Auto Merge
+
+on: pull_request
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.DEPENDABOT_AUTO_MERGE_PAT }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,7 +3,16 @@
 # whitelist
 !**
 
-!*.js
-!*.json
+!*.cjs
 !*.css
 !*.html
+!*.html.jinja
+!*.js
+!*.json
+!*.jsx
+!*.md
+!*.scss
+!*.ts
+!*.tsx
+!*.yaml
+!*.yml

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -25,7 +25,7 @@
             }
         },
         {
-            "files": "**/*.yaml",
+            "files": ["**/*.yaml", "**/*.yml"],
             "options": {
                 "tabWidth": 2
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": ".github",
+    "name": ".github-configure-status-checks",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": ".github-generalise-workflows",
+    "name": ".github",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          curl https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension?token=${{ secrets.GITHUB_TOKEN }} -o find-by-extension
           chmod +x find-by-extension
       - id: find-python
         run: |

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -13,11 +13,9 @@ jobs:
       web: ${{ steps.find-web.outputs.result }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          repository: "SituDevelopment/automation"
-          sparse-checkout: "find-by-extension"
-          token: ${{ github.token }}
+      - run: |
+          curl -H "Authorization: token ${{ github.token }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          chmod +x find-by-extension
       - id: find-python
         run: |
           find-by-extension ".py" > /dev/null

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension?token=${{ secrets.GITHUB_TOKEN }} -o find-by-extension
+          curl -H "Authorization: token ${{ secrets.DOWNLOAD_FIND_BY_EXTENSION }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
           chmod +x find-by-extension
       - id: find-python
         run: |

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -18,14 +18,14 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          if [ -n $(./find-by-extension ".py") ]; then
+          if [[ -n $(./find-by-extension ".py") ]]; then
               echo "result=true" >> "$GITHUB_OUTPUT"
           else
               echo "result=false" >> "$GITHUB_OUTPUT"
           fi
       - id: find-web
         run: |
-          if [ -n $(./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]; then
+          if [[ -n $(./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
             echo "result=false" >> "$GITHUB_OUTPUT"

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -13,13 +13,28 @@ jobs:
       web: ${{ steps.find-web.outputs.result }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: "SituDevelopment/automation"
       - id: find-python
-        run: echo "result=${{ hashFiles('**.py') }}" >> "$GITHUB_OUTPUT"
+        run: |
+          find-by-extension ".py" > /dev/null
+          if [ $? -eq 0 ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+          fi
       - id: find-web
-        run: echo "result=${{ hashFiles('**.cjs, **.css, **.html, **.html.jinja, **.js, **.json, **.jsx, **.md, **.scss, **.ts, **.tsx, **.yaml, **.yml') }}" >> "$GITHUB_OUTPUT"
+        run: |
+          find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
+          if [ $? -eq 0 ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+          fi
 
   black:
-    if: needs.find.outputs.python
+    if: fromJSON(needs.find.outputs.python)
     needs: find
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +42,7 @@ jobs:
       - uses: psf/black@stable
 
   isort:
-    if: needs.find.outputs.python
+    if: fromJSON(needs.find.outputs.python)
     needs: find
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +53,7 @@ jobs:
           requirements-files: "requirements.txt"
 
   prettier:
-    if: needs.find.outputs.web
+    if: fromJSON(needs.find.outputs.web)
     needs: find
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +67,7 @@ jobs:
         run: prettier --check .
 
   pylint:
-    if: needs.find.outputs.python
+    if: fromJSON(needs.find.outputs.python)
     needs: find
     runs-on: ubuntu-latest
     steps:

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -18,16 +18,14 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          ./find-by-extension ".py"
-          if [ $? -eq 0 ]; then
-            echo "result=true" >> "$GITHUB_OUTPUT"
+          if [ -n $(./find-by-extension ".py") ]; then
+              echo "result=true" >> "$GITHUB_OUTPUT"
           else
-            echo "result=false" >> "$GITHUB_OUTPUT"
+              echo "result=false" >> "$GITHUB_OUTPUT"
           fi
       - id: find-web
         run: |
-          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml"
-          if [ $? -eq 0 ]; then
+          if [ -n $(./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
             echo "result=false" >> "$GITHUB_OUTPUT"

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -6,20 +6,6 @@ on:
       - $default_branch
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Installing Pylint
-        run: |
-          python -m pip install --upgrade pip
-          pip install pylint
-      - name: Running Pylint
-        run: pylint .
-
   black:
     runs-on: ubuntu-latest
     steps:
@@ -34,3 +20,17 @@ jobs:
         with:
           configuration: "--check-only --diff --profile black"
           requirements-files: "requirements.txt"
+
+  pylint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Installing Pylint
+        run: |
+          python -m pip install --upgrade pip
+          pip install pylint
+      - name: Running Pylint
+        run: pylint .

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -12,6 +12,7 @@ jobs:
       python: ${{ steps.find-python.outputs.result }}
       web: ${{ steps.find-web.outputs.result }}
     steps:
+      - uses: actions/checkout@v4
       - id: find-python
         run: echo "result=${{ hashFiles('**.py') }}" >> "$GITHUB_OUTPUT"
       - id: find-web

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -21,6 +21,18 @@ jobs:
           configuration: "--check-only --diff --profile black"
           requirements-files: "requirements.txt"
 
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - name: Installing Prettier
+        run: npm install --global prettier
+      - name: Running Prettier
+        run: prettier --check .
+
   pylint:
     runs-on: ubuntu-latest
     steps:

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -18,7 +18,7 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          ./find-by-extension ".py" > /dev/null
+          ./find-by-extension ".py"
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
@@ -26,7 +26,7 @@ jobs:
           fi
       - id: find-web
         run: |
-          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
+          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml"
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: "SituDevelopment/automation"
+          sparse-checkout: "find-by-extension"
+          token: ${{ github.token }}
       - id: find-python
         run: |
           find-by-extension ".py" > /dev/null

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -18,7 +18,7 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          find-by-extension ".py" > /dev/null
+          ./find-by-extension ".py" > /dev/null
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
@@ -26,7 +26,7 @@ jobs:
           fi
       - id: find-web
         run: |
-          find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
+          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl -H "Authorization: token ${{ github.token }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
           chmod +x find-by-extension
       - id: find-python
         run: |

--- a/workflow-templates/check-code-style.yaml
+++ b/workflow-templates/check-code-style.yaml
@@ -6,13 +6,28 @@ on:
       - $default_branch
 
 jobs:
+  find:
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.find-python.outputs.result }}
+      web: ${{ steps.find-web.outputs.result }}
+    steps:
+      - id: find-python
+        run: echo "result=${{ hashFiles('**.py') }}" >> "$GITHUB_OUTPUT"
+      - id: find-web
+        run: echo "result=${{ hashFiles('**.cjs, **.css, **.html, **.html.jinja, **.js, **.json, **.jsx, **.md, **.scss, **.ts, **.tsx, **.yaml, **.yml') }}" >> "$GITHUB_OUTPUT"
+
   black:
+    if: needs.find.outputs.python
+    needs: find
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
 
   isort:
+    if: needs.find.outputs.python
+    needs: find
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +37,8 @@ jobs:
           requirements-files: "requirements.txt"
 
   prettier:
+    if: needs.find.outputs.web
+    needs: find
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +51,8 @@ jobs:
         run: prettier --check .
 
   pylint:
+    if: needs.find.outputs.python
+    needs: find
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/workflow-templates/check-dependencies.yaml
+++ b/workflow-templates/check-dependencies.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          curl https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension?token=${{ secrets.GITHUB_TOKEN }} -o find-by-extension
           chmod +x find-by-extension
       - id: find-python
         run: |

--- a/workflow-templates/check-dependencies.yaml
+++ b/workflow-templates/check-dependencies.yaml
@@ -6,7 +6,20 @@ on:
       - $default_branch
 
 jobs:
+  find:
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.find-python.outputs.result }}
+      web: ${{ steps.find-web.outputs.result }}
+    steps:
+      - id: find-python
+        run: echo "result=${{ hashFiles('**.py') }}" >> "$GITHUB_OUTPUT"
+      - id: find-web
+        run: echo "result=${{ hashFiles('**.cjs, **.css, **.html, **.html.jinja, **.js, **.json, **.jsx, **.md, **.scss, **.ts, **.tsx, **.yaml, **.yml') }}" >> "$GITHUB_OUTPUT"
+
   pip:
+    if: needs.find.outputs.python
+    needs: find
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,6 +34,8 @@ jobs:
           fi
 
   npm:
+    if: needs.find.outputs.web
+    needs: find
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/workflow-templates/check-dependencies.yaml
+++ b/workflow-templates/check-dependencies.yaml
@@ -13,11 +13,9 @@ jobs:
       web: ${{ steps.find-web.outputs.result }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          repository: "SituDevelopment/automation"
-          sparse-checkout: "find-by-extension"
-          token: ${{ github.token }}
+      - run: |
+          curl -H "Authorization: token ${{ github.token }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          chmod +x find-by-extension
       - id: find-python
         run: |
           find-by-extension ".py" > /dev/null

--- a/workflow-templates/check-dependencies.yaml
+++ b/workflow-templates/check-dependencies.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension?token=${{ secrets.GITHUB_TOKEN }} -o find-by-extension
+          curl -H "Authorization: token ${{ secrets.DOWNLOAD_FIND_BY_EXTENSION }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
           chmod +x find-by-extension
       - id: find-python
         run: |

--- a/workflow-templates/check-dependencies.yaml
+++ b/workflow-templates/check-dependencies.yaml
@@ -18,14 +18,14 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          if [ -n $(./find-by-extension ".py") ]; then
+          if [[ -n $(./find-by-extension ".py") ]]; then
               echo "result=true" >> "$GITHUB_OUTPUT"
           else
               echo "result=false" >> "$GITHUB_OUTPUT"
           fi
       - id: find-web
         run: |
-          if [ -n $(./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]; then
+          if [[ -n $(./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
             echo "result=false" >> "$GITHUB_OUTPUT"

--- a/workflow-templates/check-dependencies.yaml
+++ b/workflow-templates/check-dependencies.yaml
@@ -13,13 +13,28 @@ jobs:
       web: ${{ steps.find-web.outputs.result }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: "SituDevelopment/automation"
       - id: find-python
-        run: echo "result=${{ hashFiles('**.py') }}" >> "$GITHUB_OUTPUT"
+        run: |
+          find-by-extension ".py" > /dev/null
+          if [ $? -eq 0 ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+          fi
       - id: find-web
-        run: echo "result=${{ hashFiles('**.cjs, **.css, **.html, **.html.jinja, **.js, **.json, **.jsx, **.md, **.scss, **.ts, **.tsx, **.yaml, **.yml') }}" >> "$GITHUB_OUTPUT"
+        run: |
+          find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
+          if [ $? -eq 0 ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+          fi
 
   pip:
-    if: needs.find.outputs.python
+    if: fromJSON(needs.find.outputs.python)
     needs: find
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +50,7 @@ jobs:
           fi
 
   npm:
-    if: needs.find.outputs.web
+    if: fromJSON(needs.find.outputs.web)
     needs: find
     runs-on: ubuntu-latest
     steps:

--- a/workflow-templates/check-dependencies.yaml
+++ b/workflow-templates/check-dependencies.yaml
@@ -18,16 +18,14 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          ./find-by-extension ".py"
-          if [ $? -eq 0 ]; then
-            echo "result=true" >> "$GITHUB_OUTPUT"
+          if [ -n $(./find-by-extension ".py") ]; then
+              echo "result=true" >> "$GITHUB_OUTPUT"
           else
-            echo "result=false" >> "$GITHUB_OUTPUT"
+              echo "result=false" >> "$GITHUB_OUTPUT"
           fi
       - id: find-web
         run: |
-          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml"
-          if [ $? -eq 0 ]; then
+          if [ -n $(./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml") ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
             echo "result=false" >> "$GITHUB_OUTPUT"

--- a/workflow-templates/check-dependencies.yaml
+++ b/workflow-templates/check-dependencies.yaml
@@ -12,6 +12,7 @@ jobs:
       python: ${{ steps.find-python.outputs.result }}
       web: ${{ steps.find-web.outputs.result }}
     steps:
+      - uses: actions/checkout@v4
       - id: find-python
         run: echo "result=${{ hashFiles('**.py') }}" >> "$GITHUB_OUTPUT"
       - id: find-web

--- a/workflow-templates/check-dependencies.yaml
+++ b/workflow-templates/check-dependencies.yaml
@@ -18,7 +18,7 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          ./find-by-extension ".py" > /dev/null
+          ./find-by-extension ".py"
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
@@ -26,7 +26,7 @@ jobs:
           fi
       - id: find-web
         run: |
-          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
+          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml"
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else

--- a/workflow-templates/check-dependencies.yaml
+++ b/workflow-templates/check-dependencies.yaml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: "SituDevelopment/automation"
+          sparse-checkout: "find-by-extension"
+          token: ${{ github.token }}
       - id: find-python
         run: |
           find-by-extension ".py" > /dev/null

--- a/workflow-templates/check-dependencies.yaml
+++ b/workflow-templates/check-dependencies.yaml
@@ -18,7 +18,7 @@ jobs:
           chmod +x find-by-extension
       - id: find-python
         run: |
-          find-by-extension ".py" > /dev/null
+          ./find-by-extension ".py" > /dev/null
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else
@@ -26,7 +26,7 @@ jobs:
           fi
       - id: find-web
         run: |
-          find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
+          ./find-by-extension ".cjs" ".css" ".html" ".html.jinja" ".js" ".json" ".jsx" ".md" ".scss" ".ts" ".tsx" ".yaml" ".yml" > /dev/null
           if [ $? -eq 0 ]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
           else

--- a/workflow-templates/check-dependencies.yaml
+++ b/workflow-templates/check-dependencies.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl -H "Authorization: token ${{ github.token }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://raw.githubusercontent.com/SituDevelopment/automation/main/find-by-extension -o find-by-extension
           chmod +x find-by-extension
       - id: find-python
         run: |

--- a/workflow-templates/dependabot-auto-merge.yaml
+++ b/workflow-templates/dependabot-auto-merge.yaml
@@ -9,7 +9,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
-          target:
-            - patch
-            - minor
+          target: minor
           github-token: ${{ secrets.DEPENDABOT_AUTO_MERGE_PAT }}


### PR DESCRIPTION
The `workflow-templates` directory contains [starter workflows](https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization) which can be [reused in other repositories](https://docs.github.com/en/actions/using-workflows/using-starter-workflows) across the organisation.

The changes proposed here configure status checks to run only in appropriate repositories by utilising the `find` job to determine the existence of Python and web files using [Automation's `find-by-extension`](https://github.com/SituDevelopment/automation/blob/main/find-by-extension). Further jobs run conditionally depending on the outputs from `find`.