### PR TITLE
Install Poetry before Python setup

### DIFF
--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -52,9 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: pip install poetry
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10" # trailing zero
-      - run: |
-          pip install poetry
-          poetry install
+          cache: poetry
+      - run: poetry install


### PR DESCRIPTION
I believe the issue with caching Poetry dependencies (https://github.com/SituDevelopment/.github/issues/86) was that Poetry was not installed (see https://github.com/SituDevelopment/entegy-sdk-python/actions/runs/7792234802/job/21353847936#step:3:13).

https://github.com/SituDevelopment/.github/pull/87 removed the cache as a workaround, but I believe simply installing poetry before calling the `actions/setup-python` action will enable the check to work as desired and improve dependency installation times
