### PR TITLE
Revert "Feature: Improve Language Specific Interface"

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -14,9 +14,6 @@ on:
         default: true
 
 jobs:
-  all:
-    uses: ./.github/workflows/all.yaml
-
   code-style-black:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -3,9 +3,6 @@ name: TypeScript Status Checks
 on: workflow_call
 
 jobs:
-  all:
-    uses: ./.github/workflows/all.yaml
-
   linting-tsc:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
While the implicit calling of `all` is nice, it complicates the names of the status checks by prepending `typescript / ` or `python / ` to `all / dependencies-npm` and `all / code-style-prettier`.

This check occurred:
![image](https://github.com/SituDevelopment/.github/assets/79405475/54a39c26-5244-4c14-9656-9fe45a1f1b90)

However this check was required by requiring `all / dependencies-npm` in [the ruleset](https://github.com/organizations/SituDevelopment/settings/rules/169999).
![image](https://github.com/SituDevelopment/.github/assets/79405475/08e8fb02-2009-4b86-a844-203c100f1e4a)

This change is being reverted such that status check requirements can be defined with inheritance despite requiring the duplication of the call to `all` in every repository.