### PR TITLE
Fix labeller permissions in workflow

### DIFF
--- a/.github/workflows/labeller.yaml
+++ b/.github/workflows/labeller.yaml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/labeler@v5


### PR DESCRIPTION
The labeller doesn't have permissions to add labels to a PR due to a change in permission requirements, add issues:write perms to the workflow.